### PR TITLE
Don't run flutter test for now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Analyze
         run: flutter analyze
-
-      - name: Run tests
-        run: flutter test
+# Temporarily removing this since we need to figure out how to avoid the
+# mapbox credentials file missing in the github environment
+# - name: Run tests
+#   run: flutter test


### PR DESCRIPTION
I guess it's borked because it's looking for the credentials file and that doesn't exist in the github environment. I was trying to figure out how to make the file on the fly and fill it with nonsense but that doesn't seem to work so I'm abandoning this effort for now. We'll still get the linting so I think it's worth keeping the github action.